### PR TITLE
Get channel name from api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in ruboty-timeline.gemspec
 gemspec
-
-gem 'ruboty-slack'

--- a/lib/ruboty/timeline/actions/say.rb
+++ b/lib/ruboty/timeline/actions/say.rb
@@ -12,7 +12,7 @@ module Ruboty
         end
 
         def call
-          if room =~ /current/
+          if room =~ /current_(?!all$).+/
             notifier.ping "#{body}\n(\##{room})", username: from, icon_url: icon(from), link_names: true
           end
         end
@@ -28,7 +28,15 @@ module Ruboty
         end
 
         def room
-          message.from.gsub(/@.*$/, '')
+          channels.find { |channel| channel['id'] == message.from }['name']
+        end
+
+        def channels
+          @channels ||= JSON.parse(open(api_channels_list).read)['channels']
+        end
+
+        def api_channels_list
+          "https://slack.com/api/channels.list?token=#{ENV['RUBOTY_TIMELINE_TOKEN']}"
         end
 
         def notifier

--- a/ruboty-timeline.gemspec
+++ b/ruboty-timeline.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "ruboty"
-  spec.add_dependency "ruboty-slack"
   spec.add_dependency "slack-notifier"
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
## :sparkles: Purpose

This pull request fixes the failure to get channel name with `ruby-slack_rtm`.

## :muscle: Policy

When using `ruboty-slack_rtm`, `room` method returns channel_id. Thus I add the method to get channel_name with Slack API by channel_id.

## ✅ Test

I test on my slack workspace and confirm following points:

- Post to `current_all` channel at once
- Post to `current_all` channel only the message posted in `current_xxx` channel