### PR TITLE
Use users.conversations instead

### DIFF
--- a/lib/ruboty/timeline/actions/say.rb
+++ b/lib/ruboty/timeline/actions/say.rb
@@ -36,7 +36,7 @@ module Ruboty
         end
 
         def api_channels_list
-          "https://slack.com/api/channels.list?token=#{ENV['RUBOTY_TIMELINE_TOKEN']}"
+          "https://slack.com/api/users.conversations?token=#{ENV['RUBOTY_TIMELINE_TOKEN']}"
         end
 
         def notifier


### PR DESCRIPTION
SSIA. 

Because of this.

> [ERROR] This method is retired and can no longer be used. Please use conversations.list or users.conversations instead. Learn more: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api.
